### PR TITLE
Fix event propagation issue with light toggles

### DIFF
--- a/app/assets/javascripts/form.js.erb
+++ b/app/assets/javascripts/form.js.erb
@@ -157,9 +157,10 @@ $(function() {
   });
 
 
-  // CURT these following two methods are what is fucked up I think
   $('.sequence-holder').on('mousedown touchstart', '.on-off label', function(e){
     console.log( "69BOT - 8 OK");
+    e.preventDefault();
+    e.stopPropagation();
     clicked =  true;
     activeLight = $(this);
     activeLight.find('.light').toggleClass('lit');


### PR DESCRIPTION
It was just an event propagation problem. The browser is giving me a weird visual delay on the checkboxes while dragging, but when I release the mouse all of the lights and checkboxes are in sync. N*sync. Whatever.

Definitely not worth a six-pack, but I'll take it if your insistent.

You should also break apart your forms.js.erb file into separate files. It's pretty unwieldy. 

Kisses,

Curt